### PR TITLE
Added direct installation as CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     <img src="https://github.com/rektdeckard/departure-mono/blob/main/public/assets/departure-og.png?raw=true" alt="Departure Mono" width="630">
   </a>
   <br>
+  <br>
     Departure Mono
   <br>
 </h1>
@@ -15,6 +16,23 @@
 Departure Mono is a monospaced pixel font inspired by the constraints of early command-line and graphical user interfaces, the tiny pixel fonts of the late 90s/early 00s, and sci-fi concepts from film and television.
 
 ## Installation
+
+If you're making a web thing, you can use the following HTML and CSS :
+
+```
+<!-- HTML in your document's head -->
+<link rel="preconnect" href="https://departuremono.com">
+<link rel="stylesheet" href="https://departuremono.com/mono.css">
+```
+
+```
+<!-- Import in CSS -->
+@import url("https://departuremono.com/mono.css");
+
+:root {
+  font-family: Departure Mono, monospace;
+}
+```
 
 ### Homebrew
 

--- a/public/mono.css
+++ b/public/mono.css
@@ -1,0 +1,15 @@
+@font-face {
+  font-family: 'Departure Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url(./assets/DepartureMono-1.500.woff) format('woff'), url(./assets/DepartureMono-1.500.woff2) format('woff2');
+  unicode-range: U+0021–007D, U+00A1–00BF, U+00C0–00FF, U+0100–017F, U+0180–0199, U+01A0–01FF, U+0218–021F, U+0232–0233, U+0244, U+0253–0294, U+A78B–A78C, U+037A–03CE, U+0400–045F, U+0460–048F, U+0490–04FF, U+0500–0527, U+0E3F, U+0192, U+2030–203A, U+2044–2052, U+20A3–20BF, U+2113–212E, U+2190–21B5, U+2202–222B, U+2248–2265, U+2500–257F, U+2580–259F, U+25A0–25CC, U+2605–266C, U+2726–2727, U+276C–2771, U+1E00–1EFF, U+1FB82–1FB8B;
+}
+
+@font-face {
+  font-family: 'Departure Mono Regular';
+  font-style: normal;
+  font-weight: 400;
+  src: url(./assets/DepartureMono-Regular.woff) format('woff'), url(./assets/DepartureMono-Regular.woff2) format('woff2');
+  unicode-range: U+0021–007D, U+00A1–00BF, U+00C0–00FF, U+0100–017F, U+0180–0199, U+01A0–01FF, U+0218–021F, U+0232–0233, U+0244, U+0253–0294, U+A78B–A78C, U+037A–03CE, U+0400–045F, U+0460–048F, U+0490–04FF, U+0500–0527, U+0E3F, U+0192, U+2030–203A, U+2044–2052, U+20A3–20BF, U+2113–212E, U+2190–21B5, U+2202–222B, U+2248–2265, U+2500–257F, U+2580–259F, U+25A0–25CC, U+2605–266C, U+2726–2727, U+276C–2771, U+1E00–1EFF, U+1FB82–1FB8B;
+}


### PR DESCRIPTION
This pull request adds an easier way to install the Departure Mono font directly via CSS for web projects. The update includes two installation methods:

1. **HTML Integration** : dev can now include the font in your web project simply by adding the following HTML tags to your document's head :

   ```html
   <link rel="preconnect" href="https://departuremono.com">
   <link rel="stylesheet" href="https://departuremono.com/mono.css">
   ```

2. **CSS Import** : Additionally, dev can import the font directly into your CSS using the `@import` rule :

   ```css
   @import url("https://departuremono.com/mono.css");

   :root {
     font-family: Departure Mono, monospace;
   }
   ```

Both methods are included in the updated installation instructions section, which provides a more streamlined and convenient option for web developers to quickly integrate Departure Mono into their projects.

**Changes Made** :

* Added file `mono.css` at `/public` to access CSS file in public.
* Updated the **Installation** section in README to include the new CSS method for direct font integration 
